### PR TITLE
load temperature data from kunterbunt.vm.rzl instead of Xively

### DIFF
--- a/dashboards/rzl.erb
+++ b/dashboards/rzl.erb
@@ -23,7 +23,7 @@ $(function() {
     </li>
 
     <li data-row="2" data-col="1" data-sizex="1" data-sizey="1">
-      <div data-id="Temperatur_Raum_Beamerplattform" data-view="Graph" data-title="Temperatur" data-suffix="°C"></div>
+      <div data-id="Temperaturen" data-view="Iframe" data-url="http://kunterbunt.vm.rzl/dashboard-solo/db/allgemeines?refresh=1m&panelId=6&orgId=1&theme=dark"></div>
     </li>
 
     <li data-row="1" data-col="5" data-sizex="2" data-sizey="1">


### PR DESCRIPTION
The Xively temperature data does not update causing
the temperature widget to show outdated data.

I suggest fixing the issue with this commit by
changing the temperature widget from Xively to
our Graphite + Grafana installation located at
kunterbunt.vm.rzl.

![temperaturen](https://user-images.githubusercontent.com/230440/27994276-a760429e-64ba-11e7-87d5-c379ecf07c7a.png)
