### PR TITLE
load temperature data from Grafana instead of Xively

### DIFF
--- a/dashboards/rzl.erb
+++ b/dashboards/rzl.erb
@@ -23,7 +23,7 @@ $(function() {
     </li>
 
     <li data-row="2" data-col="1" data-sizex="1" data-sizey="1">
-      <div data-id="Temperatur_Raum_Beamerplattform" data-view="Graph" data-title="Temperatur" data-suffix="°C"></div>
+      <div data-id="Temperatur_Beamerplattform" data-view="Graph" data-title="Temperatur" data-suffix="°C"></div>
     </li>
 
     <li data-row="1" data-col="5" data-sizex="2" data-sizey="1">

--- a/jobs/grafana.rb
+++ b/jobs/grafana.rb
@@ -1,0 +1,25 @@
+require 'httparty'
+require 'time'
+
+SCHEDULER.every '20s', :first_in => 0 do |job|
+  begin
+    # Instatiates an empty data hash. This will store our variables and associated Xively value.
+    data = {}
+    grafana_data = HTTParty.post('http://kunterbunt.vm.rzl/api/datasources/proxy/1/render', { :body => 'target=alias(rzl.service.heizung.temp.beamerplattform%2C%20\'Temperatur_Beamerplattform\')&from=-24h&until=now&format=json&maxDataPoints=10'})
+    # This code assigns the variables to incoming Xively data and stores the result in a hash
+    grafana_data.each do |n|
+        data[n['target']] = n
+    end
+
+    # Sends the data to the DOM.
+    data.each do |key, val|
+      if val['datapoints']
+        datapoints = []
+        val['datapoints'].each do |dpval|
+          datapoints.push({x: dpval[1], y: dpval[0].to_f})
+        end
+      end
+      send_event(key, {current: datapoints[-1][:y], points: datapoints, displayedValue: datapoints[-1][:y].round(2), moreinfo: ""})
+    end
+  end
+end


### PR DESCRIPTION
The Xively temperature data does not update causing
the temperature widget to show outdated data.

I suggest fixing the issue with this commit by
loading the data from kunterbunt.vm.rzl, our
local Grafana installation.

Fixes #12